### PR TITLE
[SQL] 종료 미션  조회 쿼리 변경

### DIFF
--- a/src/main/java/com/mobile/server/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/mobile/server/domain/mission/repository/MissionRepository.java
@@ -25,12 +25,14 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
 
     @Query("""
-                SELECT m
-                FROM MissionParticipation p
-                JOIN p.mission m
-                WHERE m.status = :missionStatus
-                  AND p.participationStatus != :missionParticipationStatus
-            """)
+                 SELECT m
+                 FROM MissionParticipation p
+                 RIGHT JOIN p.mission m
+                 WHERE m.status = :missionStatus
+                 GROUP BY m
+                 HAVING COUNT(CASE WHEN p.participationStatus = :missionParticipationStatus THEN 1 END) = 0\s
+                        OR COUNT(p) = 0
+            \s""")
     List<Mission> findAllByMissionStatusAndMissionParticipationStatusNot(
             @Param("missionStatus") com.mobile.server.domain.mission.e.MissionStatus missionStatus,
             @Param("missionParticipationStatus") MissionParticipationStatus status);


### PR DESCRIPTION
- 종료 미션을 조회하는 쿼리에 문제가 있어서 쿼리를 변경했습니다. 
- 문제 상황 : 기존 쿼리에는 미션 참여에 승인 혹은 반려가 하나라도 있다면 해당 미션을 반환하도록 설정 -> 요구 사항에 만족하지 않음
-  변경 사항 -> 미션에 대한 미션 참여 모두 승인 혹은 반려일 때만 해당 미션을 반환하거나, 참여가 하나도 없는 미션을 반환도록 변경