### PR TITLE
fix(Server): 서버 타임존 변경

### DIFF
--- a/src/main/java/com/mobile/server/ServerApplication.java
+++ b/src/main/java/com/mobile/server/ServerApplication.java
@@ -1,5 +1,7 @@
 package com.mobile.server;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -12,6 +14,11 @@ public class ServerApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ServerApplication.class, args);
+    }
+
+    @PostConstruct
+    public void setUp() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 
 }


### PR DESCRIPTION
- 서버 타임이 UTC 기준으로 설정되어있어, 아침 12시에 설정한 스케줄러가 UTC 시간이 적용되어 아침 8시 30분에 발생하는 문제 확인
- 이를 해결하기 위해 서버 전체의 타임존을 서울로 변경